### PR TITLE
Specify variable type for byte-compile warning

### DIFF
--- a/aa-edit-mode.el
+++ b/aa-edit-mode.el
@@ -50,7 +50,8 @@
     (rx bol "[SPLIT]")))
 
 (defcustom aa-edit-delimiter-pattern aa-edit-mlt-delimiter-regexp
-  "A delimiter (separator) regexp pattern of ASCII Art that based on `PAGE-DELIMITER'.")
+  "A delimiter (separator) regexp pattern of ASCII Art that based on `PAGE-DELIMITER'."
+  :type 'regexp)
 
 (defun aa-edit-mode--face ()
   "Return face for display AA."


### PR DESCRIPTION
Newer Emacs(>= 26) warns custom variable which does not specify 